### PR TITLE
Add support for Android 6

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -100,8 +100,9 @@ conn shared
   dpddelay=15
   dpdtimeout=30
   dpdaction=clear
-  ike=3des-sha1,aes-sha1
-  phase2alg=3des-sha1,aes-sha1
+  ike=3des-sha1,3des-sha2,aes-sha1,aes-sha1;modp1024,aes-sha2,aes-sha2;modp1024,aes256-sha2_512
+  phase2alg=3des-sha1,3des-sha2,aes-sha1,aes-sha2,aes256-sha2_512
+  sha2-truncbug=yes
 
 conn l2tp-psk
   auto=add


### PR DESCRIPTION
Android 6 has a bug.


Bug information:
* [Xiaomi MIUI forum](http://en.miui.com/forum.php?mod=redirect&goto=findpost&ptid=287003&pid=13695773)
* [Android bug 194269](https://issuetracker.google.com/issues/37070549)
* [libreswan FAQ](https://libreswan.org/wiki/FAQ#Using_SHA2_256_for_ESP_connection_establishes_but_no_traffic_passes_.28especially_Android_6.0.29)
* [Information from parent repository (hwdsl2/docker-ipsec-vpn-server)](https://github.com/hwdsl2/docker-ipsec-vpn-server/issues/15)

Tested with Xiaomi Redmi 4 Pro (MIUI Global 9.5.3.0).

